### PR TITLE
Add storage component

### DIFF
--- a/frontend/src/components/Storage.vue
+++ b/frontend/src/components/Storage.vue
@@ -1,0 +1,26 @@
+<script>
+export default {
+  props: {
+    items: Array,
+  },
+  render(createElement) {
+    return createElement(
+      'div',
+      { class: 'grid' },
+      this.items.map(func => func(createElement)),
+    );
+  },
+};
+</script>
+
+<style scoped>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+    grid-gap: 100px;
+  }
+
+  .grid > * {
+    margin: 0 auto;
+  }
+</style>


### PR DESCRIPTION
使い方

![image](https://user-images.githubusercontent.com/13715034/67616494-7a83c080-f814-11e9-9e9c-661108123500.png)

子要素のコンポーネントを生成する関数のArray↑を `items` にわたす
